### PR TITLE
sphinx-click and unit test fix for py3.11

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -89,6 +89,7 @@ sphinx:
       "sphinx.ext.napoleon",
       "sphinx.ext.autodoc",
       "sphinx.ext.viewcode",
+      "sphinx_click.ext"
     ] # A list of extra extensions to load by Sphinx (added to those already used by JB).
   local_extensions: # A list of local extensions to load by sphinx specified by "name: path" items
   recursive_update: false # A boolean indicating whether to overwrite the Sphinx config (true) or recursively update (false)

--- a/docs/api/image_processing.rst
+++ b/docs/api/image_processing.rst
@@ -1,7 +1,7 @@
 pyalfe.image_processing
 =======================
 
-automodule:: pyalfe.image_processing
+.. automodule:: pyalfe.image_processing
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -1,7 +1,6 @@
 pyalfe.main
 ===========
 
-.. automodule:: pyalfe.main
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. click:: pyalfe.main:main
+  :prog: pyalfe
+  :nested: full

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,5 +1,6 @@
 # Installation
 
+PyALFE supports Linux x86-64, Mac x86-64, and Mac arm64 and requires python >= 3.9.
 ```console
 pip install pyalfe
 ```

--- a/pyalfe/data_structure.py
+++ b/pyalfe/data_structure.py
@@ -1,26 +1,28 @@
-from enum import Enum, IntEnum
+from enum import auto, IntEnum
 import os
 from pathlib import Path
 
-
-class Modality(str, Enum):
-    T1 = 'T1'
-    T1Post = 'T1Post'
-    T2 = 'T2'
-    FLAIR = 'FLAIR'
-    GRE = 'GRE'
-    DWI = 'DWI'
-    SingleDWI = 'SingleDWI'
-    ADC = 'ADC'
-    EADC = 'EADC'
-    ASL = 'ASL'
-    PERFUSION = 'PERFUSION'
+from strenum import StrEnum
 
 
-class Orientation(str, Enum):
-    AXIAL = 'AXIAL'
-    SAGITTAL = 'SAGITTAL'
-    CORONAL = 'CORONAL'
+class Modality(StrEnum):
+    T1 = auto()
+    T1Post = auto()
+    T2 = auto()
+    FLAIR = auto()
+    GRE = auto()
+    DWI = auto()
+    SingleDWI = auto()
+    ADC = auto()
+    EADC = auto()
+    ASL = auto()
+    PERFUSION = auto()
+
+
+class Orientation(StrEnum):
+    AXIAL = auto()
+    SAGITTAL = auto()
+    CORONAL = auto()
 
 
 class Tissue(IntEnum):

--- a/pyalfe/main.py
+++ b/pyalfe/main.py
@@ -104,7 +104,7 @@ def run(
     accession : str
         the accession number for which you want to run the pipeline.
     config : str, default: ~/.config/pyalfe/config.ini
-        the path for the config file.
+        the path to the config file.
     classified_dir : str
         the path to the directory containing input classified images
     processed_dir : str
@@ -118,7 +118,7 @@ def run(
     image_processor : str, default=c3d
         image processor that is used by the pipeline.
     image_registration : str, default=greedy
-        image registration that is used by the pipeline
+        image registration that is used by the pipeline.
     overwrite : bool
         if True, the pipeline overwrites existing output images.
 

--- a/pyalfe/main.py
+++ b/pyalfe/main.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import click
 
 from pyalfe.containers import Container
-from pyalfe.tools import greedy_url, c3d_url, GREEDY_PATH, C3D_PATH
-from pyalfe.models import models_url, MODELS_PATH
+from pyalfe.models import MODELS_PATH, models_url
+from pyalfe.tools import C3D_PATH, GREEDY_PATH, c3d_url, greedy_url
 from pyalfe.utils import download_archive, extract_binary_from_archive
 from pyalfe.utils.archive import extract_tar
 
@@ -97,30 +97,34 @@ def run(
     image_registration: str,
     overwrite: bool,
 ) -> None:
-    """The run method for pyalfe.
+    """Runs the pipeline for an accession number.
 
-    Runs the pipeline for an accession number.
-    :param accession: str
-          the accession number for which you want to run the pipeline.
-    :param config: str, default: ~/.config/pyalfe/config.ini
-          the path for the config file.
-    :param classified_dir: str
-          the path to the directory containing input classified images
-    :param processed_dir: str
-          the path to the directory containing output processed images
-    :param modalities: str
-          comma separated modalities
-    :param targets: str
-          comma separated target modalities
-    :param dominant_tissue: str, default='white_matter'
-          dominant tissue
-    :param image_processor: str, default=c3d
-          image processor that is used by the pipeline.
-    :param image_registration: str, default=greedy
-          image registration that is used by the pipeline
-    :param overwrite: bool
-          if True, the pipeline overwrites existing output images.
-    :return: None
+    Parameters
+    ----------
+    accession : str
+        the accession number for which you want to run the pipeline.
+    config : str, default: ~/.config/pyalfe/config.ini
+        the path for the config file.
+    classified_dir : str
+        the path to the directory containing input classified images
+    processed_dir : str
+        the path to the directory containing output processed images
+    modalities : str
+        comma separated modalities
+    targets : str
+        comma separated target modalities
+    dominant_tissue : str, default='white_matter'
+        dominant tissue
+    image_processor : str, default=c3d
+        image processor that is used by the pipeline.
+    image_registration : str, default=greedy
+        image registration that is used by the pipeline
+    overwrite : bool
+        if True, the pipeline overwrites existing output images.
+
+    Returns
+    -------
+    None
     """
     container = Container()
     container.config.from_ini(config, required=True, envs_required=True)

--- a/pyalfe/tasks/t1_postprocessing.py
+++ b/pyalfe/tasks/t1_postprocessing.py
@@ -65,13 +65,15 @@ class T1Postprocessing(Task):
             self.image_processing.union(
                 tissue_images['deep_gray_matter'],
                 tissue_images['white_matter'],
-                temp_image
+                temp_image,
             )
             self.image_processing.dilate(temp_image, 4, temp_image)
             self.image_processing.holefill(temp_image, temp_image)
             self.image_processing.mask(temp_image, tissue_images['csf'], output_image)
 
-            self.image_processing.dilate(tissue_images['cortical_gray_matter'], 2, temp_image)
+            self.image_processing.dilate(
+                tissue_images['cortical_gray_matter'], 2, temp_image
+            )
             self.image_processing.set_subtract(output_image, temp_image, output_image)
 
             self.image_processing.dilate(output_image, -1, temp_image)
@@ -85,7 +87,9 @@ class T1Postprocessing(Task):
 
             self.image_processing.largest_mask_comp(output_image, output_image)
 
-            self.image_processing.dilate(tissue_images['cortical_gray_matter'], 2, temp_image)
+            self.image_processing.dilate(
+                tissue_images['cortical_gray_matter'], 2, temp_image
+            )
             self.image_processing.set_subtract(output_image, temp_image, output_image)
 
             self.image_processing.dilate(tissue_images['brain_stem'], 5, temp_image)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 dependencies = [
     "scipy",
+    "StrEnum",
     "numpy",
     "Click",
     "dependency_injector",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ pyalfe = "pyalfe.main:main"
 pyalfe = ["*.ini"]
 "pyalfe.templates" = ["oasis/*.nii.gz"]
 
+[tool.setuptools]
+py-modules = []
+
 [tool.ruff]
 line-length = 88
 target-version = 'py39'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ file = "LICENSE"
 [project.optional-dependencies]
 ants = ["antspyx"]
 radiomics = ["Pyradiomics"]
-docs = ["jupyter-book"]
+docs = ["jupyter-book", "sphinx-click"]
 
 [project.scripts]
 pyalfe = "pyalfe.main:main"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -168,10 +168,12 @@ class TestCrossModalityRegistration(TestTask):
         task.run(accession)
         for target in modalities_target:
             for modality in modalities:
+
+                print(modality, target)
                 output = self.pipeline_dir.get_processed_image(
                     accession, modality, f'to_{target}_{task.image_type}'
                 )
-                self.assertTrue(os.path.exists(output))
+                self.assertTrue(os.path.exists(output), f'{output} is missing.')
 
 
 class TestSingleModalitySegmentation(TestTask):


### PR DESCRIPTION
## Description
This PR fixes the issue with sphinx and click in generating the docs. It also fixes a unit test failure for py3.11.

## Related Issues
Closes #24 .

## Motivation and Context
`sphinx` was not able to generate docs for the main.py because of the use of `click`. This was resolved by using sphinx_click extension. A unit test was failing for py3.11 with the root cause being the new behaviors of str enum in py3.11. This was fixed by using StrEnum library.

## Test Plan
Manually tested the docs generation. All unit tests pass now for py3.9 and py3.11.

## Reviewers
cc
@deppen8 @stefanv 