### PR TITLE
remove the dependency on dcm2niix

### DIFF
--- a/pyalfe/utils/dicom.py
+++ b/pyalfe/utils/dicom.py
@@ -157,7 +157,7 @@ def extract_series_uid(header, default=None):
     return extract_value(header, ('0020', '000e'), default=default)
 
 
-def get_max_echo_series_crc(series: list[str]) -> str:
+def get_max_echo_series_crc(series: list[str]) -> (int, str):
     """Calculate a checksum string of the given DICOM series. Adapeted from
     https://git.fmrib.ox.ac.uk/fsl/fslpy/-/blob/main/fsl/data/dicom.py
 
@@ -189,11 +189,11 @@ def get_max_echo_series_crc(series: list[str]) -> str:
             series_uid = extract_series_uid(header)
 
     if series_uid is None:
-        return None
+        return max_echo, None
 
     crc32 = str(binascii.crc32(series_uid.encode()))
 
     if max_echo is not None and max_echo > 1:
         crc32 = f'{crc32}.{max_echo}'
 
-    return crc32
+    return max_echo, crc32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "StrEnum",
     "numpy",
     "Click",
-    "dcm2niix@git+https://github.com/rordenlab/dcm2niix@development",
     "huggingface_hub",
     "torch",
     "pandas",


### PR DESCRIPTION
## Description
This PR removes the dependency on dcm2niix. And uses SimpleITK to convert dicom to nifti. 

## Related Issues
Recently there has been a lot of issues with pip installing dcm2niix library related to the cmake version that have not been fixed by the authors. 

## Test Plan
covered by unit test.

## Reviewers
@btuan