### PR TITLE
adds slice related functionality to c3d

### DIFF
--- a/pyalfe/interfaces/c3d.py
+++ b/pyalfe/interfaces/c3d.py
@@ -88,6 +88,14 @@ class C3D:
         self.cmd += ['-o', output]
         return self
 
+    def out_list(self, output):
+        self.cmd.append('-oo')
+        if type(output) is list:
+            self.cmd += output
+        else:
+            self.cmd.append(output)
+        return self
+
     def operand(self, *op):
         self.cmd += op
         return self
@@ -98,6 +106,14 @@ class C3D:
 
     def sdt(self):
         self.cmd.append('-sdt')
+        return self
+
+    def slice(self, axis='z'):
+        self.cmd += ['-slice', axis]
+        return self
+
+    def data_type(self, dtype):
+        self.cmd += ['-type', dtype]
         return self
 
     def run(self):


### PR DESCRIPTION
## Description
As title.

## Related Issues
N/A

## Motivation and Context
C3D provides functionality to slice an image and save the slices in png format. We add those to the current C3D interface for future use.

## Test Plan
```
from pyalfe.interfaces.c3d import C3D


c3d = C3D()

c3d.operand('FLAIR.nii.gz').trim(1, 1, 1).resample().operand('128x128x32').slice('z').operand('0:-1').data_type('uchar').out_list('slice%02d.png').check_output()
```

## Reviewers
@btuan 
